### PR TITLE
Corrected sorting order. Rice Burroughs, Edgar -> Burroughs, Edgar Rice.

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -55,7 +55,7 @@
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/A_Princess_of_Mars</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/edgar-rice-burroughs_a-princess-of-mars_frank-e-schoonover</meta>
 		<dc:creator id="author">Edgar Rice Burroughs</dc:creator>
-		<meta property="file-as" refines="#author">Rice Burroughs, Edgar</meta>
+		<meta property="file-as" refines="#author">Burroughs, Edgar Rice</meta>
 		<meta property="se:url.encyclopedia.wikipedia" refines="#author">https://en.wikipedia.org/wiki/Edgar_Rice_Burroughs</meta>
 		<meta property="se:url.authority.nacoaf" refines="#author">http://id.loc.gov/authorities/names/n80039681</meta>
 		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>


### PR DESCRIPTION
"Rice" was ERB's middle name. Sorting order should be under "Burroughs", not "Rice Burroughs".